### PR TITLE
Add governance scaffolding and automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Update the owners below with your actual GitHub usernames or teams.
+# Example: @realestatereach/platform or @your-org/realestate-reach-maintainers
+* @realestatereach/maintainers

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Report a problem with the Buyer Registry prototype or docs
+labels: bug
+assignees: ''
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## Steps to reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+What you expected to happen.
+
+## Screenshots or recordings
+If applicable, add screenshots, GIFs, or console output to help explain your problem.
+
+## Environment (please complete the following information)
+- Browser & version:
+- OS:
+- Prototype version/commit:
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security reports
+    url: mailto:security@realestatereach.com
+    about: Please report security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest a new idea or enhancement for the Buyer Registry platform
+labels: enhancement
+assignees: ''
+---
+
+## Problem statement
+Describe the user problem or opportunity. Who is affected and why does it matter?
+
+## Proposed solution
+Outline your suggested change. Include UX notes, data requirements, or technical ideas.
+
+## Success criteria
+List measurable outcomes or acceptance criteria that indicate the feature is complete.
+
+## Additional context
+Link related issues, specs, research, or prototypes that provide more detail.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+- _Provide a high-level summary of the change and the persona(s) it supports._
+
+## Testing
+
+- [ ] Added or updated unit tests
+- [ ] Added or updated integration/e2e tests
+- [ ] Manually tested locally
+- [ ] Screenshots / recordings attached (if UI changes)
+
+## Checklist
+
+- [ ] Linked to issue / ADR
+- [ ] Updated docs or ADRs as needed
+- [ ] Added labels and milestones
+- [ ] Requested review from CODEOWNERS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        run: npm install
+      - name: Lint
+        run: npm run lint --if-present
+      - name: Test
+        run: npm test --if-present -- --ci
+      - name: Build
+        run: npm run build --if-present

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,33 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * 1'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project team at [conduct@realestatereach.com](mailto:conduct@realestatereach.com). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the [FAQ](https://www.contributor-covenant.org/faq). Translations are available at the [Contributor Covenant translations](https://www.contributor-covenant.org/translations).
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to Realestate Reach
+
+Thanks for your interest in helping build a buyer-first real estate marketplace. This guide outlines how to work with the repository and collaborate effectively.
+
+## Table of contents
+
+1. [Ground rules](#ground-rules)
+2. [Ways to contribute](#ways-to-contribute)
+3. [Development workflow](#development-workflow)
+4. [Commit messages](#commit-messages)
+5. [Pull request checklist](#pull-request-checklist)
+6. [Community and support](#community-and-support)
+
+## Ground rules
+
+* Review and abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+* Assume positive intent, be respectful, and default to asynchronous communication.
+* Protect customer and partner data; never upload proprietary or personally identifiable information.
+
+## Ways to contribute
+
+* **Product feedback** – Use the feature request template to share ideas that make the buyer registry more valuable.
+* **Bug reports** – File reproducible issues with clear steps, expected vs. actual behavior, and environment details.
+* **Documentation** – Improve specs, ADRs, and onboarding guides to keep stakeholders aligned.
+* **Engineering** – Pick an issue from the backlog (or propose one) and follow the workflow below.
+
+## Development workflow
+
+1. Fork the repository (or create a feature branch if you have direct access).
+2. Create an issue describing the change if one doesn’t exist already.
+3. Work in a dedicated branch, keeping commits focused and logically grouped.
+4. Run local checks (lint, tests, type checks) before pushing. The CI workflow mirrors these commands where available.
+5. Open a pull request using the provided template. Reference related issues and add screenshots for UI changes.
+6. Request review from the CODEOWNERS and address feedback promptly.
+
+## Commit messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/) to make changelog generation easier. Examples:
+
+* `feat: add wishlist geofencing controls`
+* `fix: prevent duplicate buyer onboarding emails`
+* `docs: capture Azure maps decision`
+
+## Pull request checklist
+
+Before requesting a review, ensure that:
+
+- [ ] The change is covered by an issue with acceptance criteria.
+- [ ] Tests, linters, and type checkers pass locally (where applicable).
+- [ ] Documentation, ADRs, and screenshots are updated.
+- [ ] You have added or updated relevant labels and milestones.
+- [ ] Security-sensitive changes have been reviewed with the platform/security lead.
+
+## Community and support
+
+* For help or pairing, reach out in the `#realestate-reach-dev` Slack channel.
+* Security vulnerabilities should be reported via the process in [SECURITY.md](SECURITY.md).
+* Questions about roadmap or priorities can be raised during weekly product syncs or posted in GitHub Discussions (when enabled).
+
+Welcome aboard!

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Realestate Reach
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,81 @@
 # Realestate-Reach
 
-This repository contains two main assets:
+This repository contains the early discovery assets for the Realestate Reach buyer-first marketplace. It currently includes a long-form product/engineering specification and a vanilla HTML prototype that can be used for stakeholder demos and concept validation.
+
+## Contents
 
 1. **Buyer Registry UX & Engineering Specification** – a detailed product and platform blueprint located at `docs/buyer-registry-ux-engineering-spec.md`.
 2. **Buyer Registry Experience Demo** – a static front-end prototype located in the `web/` directory that visualises the core workflows for buyers, sellers, agents, and mortgage professionals.
 
-## Running the demo
+## Getting started
+
+### Prerequisites
+
+* Any modern web browser (Chrome, Edge, Safari, or Firefox recommended).
+* Python 3 (optional) for running a local static file server.
+
+### Running the demo
 
 The prototype is built with vanilla HTML, CSS, and JavaScript (ES modules). No build step is required.
 
-1. Open `web/index.html` in any modern browser (double-click the file or serve the folder with a static web server such as `python -m http.server`).
-2. Use the navigation bar to explore landing content, onboarding flows, notifications, subscription plans, and each persona’s workspace.
-3. Interact with wishlist cards, listing insights, lead cards, and modal forms to experience the demand-led workflows described in the specification.
+1. Navigate to the `web/` directory.
+2. Serve the folder with a static web server (`python -m http.server 8000`) or open `index.html` directly in the browser.
+3. Use the navigation bar to explore landing content, onboarding flows, notifications, subscription plans, and each persona’s workspace.
+4. Interact with wishlist cards, listing insights, lead cards, and modal forms to experience the demand-led workflows described in the specification.
+
+### Demo preview
+
+Screenshots and GIFs of the prototype will live in the `docs/media/` directory. Add them as you iterate to make stakeholder demos easier.
 
 ## Repository structure
 
 ```
 ├── docs/
-│   └── buyer-registry-ux-engineering-spec.md
+│   ├── buyer-registry-ux-engineering-spec.md
+│   └── adr/
+│       └── 0001-cloud-platform-and-maps.md
 ├── web/
 │   ├── app.js
 │   ├── data.js
 │   ├── index.html
 │   └── styles.css
+├── .github/
+│   ├── CODEOWNERS
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── bug_report.md
+│   │   ├── feature_request.md
+│   │   └── config.yml
+│   ├── dependabot.yml
+│   ├── pull_request_template.md
+│   └── workflows/
+│       ├── ci.yml
+│       └── codeql.yml
+├── CONTRIBUTING.md
+├── CODE_OF_CONDUCT.md
+├── SECURITY.md
+├── LICENSE
 └── README.md
 ```
+
+## Roadmap snapshot
+
+| Theme | Next actions |
+| --- | --- |
+| **Platform alignment** | Execute ADR-0001 to finalise the Azure-first stack and replace Google Maps usage in the prototype with Azure Maps SDK. |
+| **MVP foundations** | Bootstrap a Next.js + NestJS TypeScript monorepo with shared models, Postgres/PostGIS migrations, and baseline auth. |
+| **Quality gates** | Adopt ESLint + Prettier configs, add unit/e2e tests, and expand CI to cover linting, type-checking, builds, and Playwright smoke tests. |
+| **Growth & compliance** | Integrate Stripe billing, notification services, and document privacy/consent policies aligned with Canadian regulations. |
+
+## Governance
+
+* Review the [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) and [CONTRIBUTING.md](CONTRIBUTING.md) before opening issues or pull requests.
+* Security disclosures should follow the guidance in [SECURITY.md](SECURITY.md).
+* Ownership and default reviewers are configured in [.github/CODEOWNERS](.github/CODEOWNERS). Update this file as the team grows.
 
 ## Browser compatibility
 
 The demo uses modern browser APIs (`dialog`, `structuredClone`, `crypto.randomUUID`). For the best experience, use the latest versions of Chrome, Edge, Safari, or Firefox.
+
+---
+
+If you need help turning the roadmap into actionable tickets or bootstrapping the production codebase, open an issue using the templates provided.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security policy
+
+We take the privacy and security expectations of buyers, sellers, agents, and lender partners seriously. Please follow the guidelines below when reporting security issues.
+
+## Supported versions
+
+The repository currently contains prototype assets. All branches are considered in scope for security reporting until we publish a formal release schedule.
+
+## Reporting a vulnerability
+
+1. **Do not** create a public GitHub issue or discussion describing the vulnerability.
+2. Email [security@realestatereach.com](mailto:security@realestatereach.com) with the following details:
+   * Summary of the vulnerability and potential impact
+   * Steps to reproduce (including proof-of-concept, logs, or screenshots)
+   * Suggested remediation or temporary mitigations, if known
+3. We aim to acknowledge reports within **2 business days** and provide a remediation plan or timeline within **10 business days**.
+
+If you have not received a response after 5 business days, please send a follow-up email referencing your original report.
+
+## Disclosure process
+
+* We will work with you to validate and remediate the issue before any public disclosure.
+* Credit will be provided in release notes or advisories if you would like to be acknowledged.
+* Responsible disclosure practices are appreciated; please avoid accessing, modifying, or exfiltrating data beyond what is necessary to demonstrate the vulnerability.
+
+Thank you for helping us keep Realestate Reach secure.

--- a/docs/adr/0001-cloud-platform-and-maps.md
+++ b/docs/adr/0001-cloud-platform-and-maps.md
@@ -1,0 +1,36 @@
+# ADR 0001: Cloud platform and maps provider
+
+* **Status**: Proposed
+* **Date**: 2024-02-19
+* **Decision drivers**:
+  * Align early prototypes with the target production environment to reduce rework.
+  * Maintain consistency between product specification (Azure leaning) and prototype implementation (recent Google Maps experiments).
+  * Leverage managed services that accelerate time-to-market for geospatial matching and communications.
+
+## Context
+
+The Buyer Registry concept requires geospatial search, secure identity management, role-based entitlements, and real-time notifications. The engineering specification highlights Azure Active Directory B2C, Azure PostgreSQL, SignalR, and Cognitive Search, while a recent prototype branch added a Google Maps integration for visualising wishlists.
+
+Running mixed Azure and Google Cloud services introduces duplicated billing, security policies, and SDK maintenance overhead. Choosing a single cloud "golden path" now will streamline the MVP build and make it easier to enable CI/CD, observability, and cost controls.
+
+## Decision
+
+Adopt an **Azure-first** deployment and mapping strategy for the MVP:
+
+* Platform: Azure App Service (or Azure Kubernetes Service for scale), Azure Database for PostgreSQL Flexible Server with PostGIS, Azure Blob Storage, Azure Key Vault, Azure Front Door, and Azure Monitor/Application Insights.
+* Identity & access: Azure Active Directory B2C for user authentication with custom policies for buyer, seller, agent, and lender roles.
+* Real-time messaging: Azure SignalR Service for chat, notifications, and match updates.
+* Geospatial visualisation: Azure Maps Web SDK for the buyer/seller experiences, replacing the experimental Google Maps integration in the prototype.
+
+## Consequences
+
+* Prototype work that relies on Google Maps must be ported to Azure Maps to avoid API key sprawl.
+* Engineering teams can take advantage of a consistent Azure security model, including Key Vault and managed identities, when integrating services.
+* Future ADRs can focus on service-level concerns (e.g., eventing, search) knowing that Azure is the default.
+* If requirements change (e.g., strong preference for Google Maps features), a follow-up ADR should document the rationale for revisiting this decision.
+
+## Alternatives considered
+
+* **Hybrid Azure + Google Cloud** – Provides best-of-breed per service but increases governance and DevOps overhead; rejected for MVP.
+* **Full Google Cloud Platform** – Would align with the prototype experiment but contradicts existing stakeholder alignment and documentation; requires re-authoring identity strategy.
+* **Multi-tenant SaaS** – Using third-party proptech platforms would reduce build effort but fails the buyer-first differentiation and data ownership goals.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "buyer-registry-demo",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "buyer-registry-demo",
+      "version": "1.0.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add contributor docs, security policy, and license information to formalize collaboration
- introduce issue/pr templates, CODEOWNERS, Dependabot, and CI/CodeQL workflows for better hygiene
- capture an Azure-first platform decision in ADR-0001 and expand the README roadmap

## Testing
- not run (documentation and configuration changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e58f99e2c0832b98f433f35a630f45